### PR TITLE
feat: add SQLALCHEMY_ENGINE_OPTIONS to generic_parameters.py

### DIFF
--- a/oarepo/config/generic_parameters.py
+++ b/oarepo/config/generic_parameters.py
@@ -101,6 +101,18 @@ def configure_generic_parameters(
         f"/{env.INVENIO_DATABASE_DBNAME}"
     )
 
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        "pool_pre_ping": False,
+        "pool_recycle": 300,
+        # set a more agressive timeout to ensure http requests don't wait for long
+        "pool_timeout": 10,
+        # Ensure the database is using the UTC timezone for interpreting timestamps (Postgres only).
+        # This overrides any default setting (e.g. in postgresql.conf). Invenio expects the DB to receive
+        # and provide UTC timestamps in all cases, so it's important that this doesn't get changed.
+        "connect_args": {"options": "-c timezone=UTC"},
+    }
+    """SQLAlchemy engine options."""
+
     # i18n
     BABEL_DEFAULT_LOCALE = "en"
     BABEL_DEFAULT_TIMEZONE = "Europe/Prague"


### PR DESCRIPTION
Add SQLALCHEMY_ENGINE_OPTIONS from invenio-app-rdm config to generic_parameters.py.

Sets pool_pre_ping=False, pool_recycle=300s, pool_timeout=10s, and forces UTC timezone for Postgres timestamps via connect_args.