### PR TITLE
fix: make resolve_invenio.sh portable to BSD sed/grep

### DIFF
--- a/tools/resolve_invenio.sh
+++ b/tools/resolve_invenio.sh
@@ -59,10 +59,10 @@ find_python_sources() {
 #
 # Emits names like:  invenio_records_resources  pytest_invenio
 extract_invenio_modules() {
-    grep -hE '^\s*(import|from)\s+(invenio[a-zA-Z0-9_]*|pytest_invenio)' \
+    grep -hE '^[[:space:]]*(import|from)[[:space:]]+(invenio[a-zA-Z0-9_]*|pytest_invenio)' \
             "$@" 2>/dev/null \
         | sed -E \
-            -e 's/^\s*(import|from)\s+//' \
+            -e 's/^[[:space:]]*(import|from)[[:space:]]+//' \
             -e 's/[.([:space:]].*//'       \
         | grep -E '^(invenio|pytest_invenio)' \
         | sort -u \


### PR DESCRIPTION
## Summary
- Replace `\s` with the POSIX `[[:space:]]` class in the `grep` and `sed` patterns inside `extract_invenio_modules` (`tools/resolve_invenio.sh`).

## Why
On macOS (BSD userland), `sed -E` does not recognise `\s`, even though `grep -E` happens to tolerate it. The first `sed` substitution that strips the leading `import`/`from` keyword silently failed, leaving every line prefixed with `from ` and dropping it from the downstream `grep -E '^(invenio|...)'` filter. The end result was a confusing run that reports many Python source files but `Unique invenio modules: 0`.

Reproduced on macOS 14 / 15 with the default `sed` (no GNU coreutils installed):

```
$ ./resolve_invenio.sh oarepo_requests
[info]  Python source files : 77
[info]  Unique invenio modules: 0
[warn]  No invenio imports found.
```

After the patch, the same invocation correctly enumerates the imported `invenio_*` modules and emits `pyproject.toml`-ready constraints.

`[[:space:]]` is the POSIX equivalent of `\s` for ASCII whitespace and is supported by both GNU and BSD `sed`/`grep`, so behaviour on Linux is unchanged.

## Test plan
- [ ] Run `./tools/resolve_invenio.sh <some-source-dir>` on macOS with a non-empty `.venv`; confirm a non-zero `Unique invenio modules` count and constraints printed to stdout.
- [ ] Run the same command on Linux to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)